### PR TITLE
feat: add NFC charm generator and viewer pages

### DIFF
--- a/nfc-charm.html
+++ b/nfc-charm.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>NFCお守り作成</title>
+<style>
+body{font-family:sans-serif;margin:1em;max-width:600px;}
+input,button{font-size:1rem;width:100%;padding:.6em;margin-top:.5em;box-sizing:border-box;}
+#result{margin-top:1em;word-break:break-all;}
+#toast{position:fixed;bottom:1em;left:50%;transform:translateX(-50%);background:#333;color:#fff;padding:.5em 1em;border-radius:4px;opacity:0;transition:opacity .3s;}
+#toast.show{opacity:1;}
+</style>
+</head>
+<body>
+<h1>NFCお守り作成</h1>
+<p>トークンを入力し、URLを生成してNFCタグに書き込みます。</p>
+<input id="token" placeholder="token">
+<button id="make">URL生成</button>
+<div id="result"></div>
+<div id="writeArea" style="display:none;">
+  <button id="write">タグに書き込む</button>
+</div>
+<div id="fallback" style="display:none;">
+  <p>Web NFCが利用できません。このURLをアプリで書き込んでください。</p>
+</div>
+<div id="toast"></div>
+<script>
+function showToast(msg){
+  const t=document.getElementById('toast');
+  t.textContent=msg;
+  t.className='show';
+  setTimeout(()=>t.className='',3000);
+}
+const tokenInput=document.getElementById('token');
+const result=document.getElementById('result');
+let url='';
+document.getElementById('make').onclick=()=>{
+  const t=encodeURIComponent(tokenInput.value.trim());
+  if(!t){showToast('トークンを入力してください');return;}
+  const u=new URL('secret.html', location.href);
+  u.searchParams.set('t', t);
+  url=u.toString();
+  result.innerHTML='<a href="'+url+'">'+url+'</a>';
+  if('NDEFReader' in window){
+    document.getElementById('writeArea').style.display='block';
+    document.getElementById('fallback').style.display='none';
+  }else{
+    document.getElementById('writeArea').style.display='none';
+    document.getElementById('fallback').style.display='block';
+  }
+};
+document.getElementById('write').onclick=async()=>{
+  try{
+    const writer=new NDEFReader();
+    await writer.write({records:[{recordType:'url',data:url}]});
+    showToast('書き込み成功');
+  }catch(e){
+    if(e.name==='NotAllowedError'){
+      showToast('NFCの権限が必要です');
+    }else{
+      showToast('書き込み失敗: '+e.message);
+    }
+  }
+};
+</script>
+</body>
+</html>

--- a/secret.html
+++ b/secret.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>お守り</title>
+<style>
+body{font-family:sans-serif;margin:1em;text-align:center;max-width:600px;}
+#charm{width:80vw;height:80vw;max-width:300px;max-height:300px;margin:auto;display:block;}
+#message{font-size:1.2rem;margin-top:1em;}
+button{font-size:1rem;width:100%;max-width:300px;padding:.6em;margin-top:1em;}
+#toast{position:fixed;bottom:1em;left:50%;transform:translateX(-50%);background:#333;color:#fff;padding:.5em 1em;border-radius:4px;opacity:0;transition:opacity .3s;}
+#toast.show{opacity:1;}
+</style>
+</head>
+<body>
+<svg id="charm" viewBox="0 0 200 200"></svg>
+<p id="message"></p>
+<button id="save">画像保存</button>
+<div id="toast"></div>
+<script>
+function showToast(msg){
+  const t=document.getElementById('toast');
+  t.textContent=msg;
+  t.className='show';
+  setTimeout(()=>t.className='',3000);
+}
+function seedFrom(str){
+  let h=0;for(let i=0;i<str.length;i++){h=(h*31+str.charCodeAt(i))>>>0;}return h;
+}
+function rng(seed){
+  return function(){seed^=seed<<13;seed^=seed>>>17;seed^=seed<<5;return (seed>>>0)/4294967296;};
+}
+const params=new URLSearchParams(location.search);
+const token=params.get('t')||'';
+if(!token){showToast('トークンがありません');}
+const today=new Date().toISOString().slice(0,10);
+const rand=rng(seedFrom(token+today));
+const colors=['#f44336','#2196f3','#4caf50','#ff9800','#9c27b0'];
+const messages=['大吉','中吉','小吉','吉','凶'];
+const patterns=[
+  '<circle cx="100" cy="100" r="80" fill="none" stroke="currentColor" stroke-width="10"/>',
+  '<rect x="40" y="40" width="120" height="120" fill="none" stroke="currentColor" stroke-width="10"/>',
+  '<polygon points="100,20 180,180 20,180" fill="none" stroke="currentColor" stroke-width="10"/>'
+];
+const color=colors[Math.floor(rand()*colors.length)];
+const msg=messages[Math.floor(rand()*messages.length)];
+const pattern=patterns[Math.floor(rand()*patterns.length)];
+const svg=document.getElementById('charm');
+svg.innerHTML=pattern;
+svg.style.color=color;
+const msgEl=document.getElementById('message');
+msgEl.textContent=msg;
+msgEl.style.color=color;
+document.getElementById('save').onclick=()=>{
+  try{
+    const svgData=new XMLSerializer().serializeToString(svg);
+    const blob=new Blob([svgData],{type:'image/svg+xml;charset=utf-8'});
+    const url=URL.createObjectURL(blob);
+    const img=new Image();
+    img.onload=()=>{
+      const canvas=document.createElement('canvas');
+      canvas.width=200;canvas.height=200;
+      const ctx=canvas.getContext('2d');
+      ctx.fillStyle='#fff';
+      ctx.fillRect(0,0,200,200);
+      ctx.drawImage(img,0,0);
+      URL.revokeObjectURL(url);
+      const a=document.createElement('a');
+      a.download='charm.png';
+      a.href=canvas.toDataURL('image/png');
+      a.click();
+    };
+    img.onerror=()=>showToast('画像生成に失敗しました');
+    img.src=url;
+  }catch(e){showToast('保存エラー: '+e.message);}
+};
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `nfc-charm.html` with Web NFC writing UI and fallback guidance
- add `secret.html` that derives daily charm from token and allows SVG→PNG download

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689fff3234b083318a0d4e85fa8a2f5f